### PR TITLE
Remove several submodules that aren't there any more

### DIFF
--- a/sympy_bot/submodules.txt
+++ b/sympy_bot/submodules.txt
@@ -26,7 +26,6 @@ liealgebras
 logic
 matrices
 ntheory
-numerics
 parsing
 # physics is disparate enough to list each submodule separately
 
@@ -49,10 +48,8 @@ physics.vector
 physics.wigner
 
 plotting
-polynomials
 polys
 printing
-rubi
 sandbox
 series
 sets


### PR DESCRIPTION
I accidentally used ls instead of git ls, which showed some submodules that
were just empty folders from checkouts of older releases.