### PR TITLE
Improve handling of multiline changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ On Travis, there is a test that the wiki updates properly, which tests against
 https://github.com/sympy/sympy-bot/wiki/Release-Notes-Tests. This requires a
 personal access token to be installed on Travis.
 
-This token is currently given on the @sympy-bot GitHub users. To regenerate
-it, login as @sympy-bot, and go to https://github.com/settings/tokens/. Create
-a new token, checking only the `public_repo` box. Be sure to indicate in the
+This token is currently given on the @sympy-bot GitHub user. To regenerate it,
+login as @sympy-bot, and go to https://github.com/settings/tokens/. Create a
+new token, checking only the `public_repo` box. Be sure to indicate in the
 description that the token is for Travis testing, and be sure to revoke any
 old tokens. The @sympy-bot user needs push access to this repo for the test to
 work. Then go to https://travis-ci.org/sympy/sympy-bot/settings and add the

--- a/sympy_bot/__init__.py
+++ b/sympy_bot/__init__.py
@@ -1,5 +1,5 @@
 from .changelog import (get_valid_headers, get_changelog,
-    get_release_notes_filename, update_release_notes)
+    get_release_notes_filename, update_release_notes, format_change)
 
 __all__ = ['get_valid_headers', 'get_changelog', 'get_release_notes_filename',
-    'update_release_notes']
+    'update_release_notes', 'format_change']

--- a/sympy_bot/changelog.py
+++ b/sympy_bot/changelog.py
@@ -169,7 +169,7 @@ def format_change(change, pr_number, authors):
             in authors[:-1]]) + ', and ' + AUTHOR.format(author=authors[-1])
 
     indent = ' '
-    if '\n' in change:
+    if '\n\n' in change or "```" in change:
         change += '\n\n'
         indent = '  '
 

--- a/sympy_bot/tests/test_update_release_notes.py
+++ b/sympy_bot/tests/test_update_release_notes.py
@@ -125,14 +125,10 @@ def test_multiline_indent():
 
 * physics.mechanics
   * Added a center of mass function in functions.py which returns the position vector of the center of
-    mass of a system of bodies.
-
-    ([#14758](https://github.com/sympy/sympy/pull/14758) by [@NikhilPappu](https://github.com/NikhilPappu))
+    mass of a system of bodies. ([#14758](https://github.com/sympy/sympy/pull/14758) by [@NikhilPappu](https://github.com/NikhilPappu))
 
   * Added a corner case check in kane.py (Passes dummy symbols to q_ind and kd_eqs if not passed in
-     to prevent errors which shouldn't occur).
-
-    ([#14758](https://github.com/sympy/sympy/pull/14758) by [@NikhilPappu](https://github.com/NikhilPappu))
+     to prevent errors which shouldn't occur). ([#14758](https://github.com/sympy/sympy/pull/14758) by [@NikhilPappu](https://github.com/NikhilPappu))
 
 * physics.vector
   * Changed _w_diff_dcm in frame.py to get the correct results. ([#14758](https://github.com/sympy/sympy/pull/14758) by [@NikhilPappu](https://github.com/NikhilPappu))

--- a/sympy_bot/tests/test_util_functions.py
+++ b/sympy_bot/tests/test_util_functions.py
@@ -42,3 +42,27 @@ def test_format_change_multiline():
 
     ([#123](https://github.com/sympy/sympy/pull/123) by [@asmeurer](https://github.com/asmeurer))
 """
+
+    change = '* new trig solvers\n  ```\n  code\n  ```'
+    authors = ['asmeurer']
+    pr_number = '123'
+
+    assert format_change(change, pr_number, authors) == """\
+  * new trig solvers
+    ```
+    code
+    ```
+
+    ([#123](https://github.com/sympy/sympy/pull/123) by [@asmeurer](https://github.com/asmeurer))
+"""
+
+    # Make sure changes that aren't really multiline don't get the PR and
+    # author link on a separate line. From
+    # https://github.com/sympy/sympy/pull/15133
+    change = '* Used checksysodesol in test_ode.py to reduce amount of code. Also slightly modified the\n       representation of the test cases in the function, but with no changes in their values.'
+    authors = ['sudz123']
+    pr_number = '15133'
+
+    assert format_change(change, pr_number, authors) == """\
+  * Used checksysodesol in test_ode.py to reduce amount of code. Also slightly modified the\n         representation of the test cases in the function, but with no changes in their values. ([#15133](https://github.com/sympy/sympy/pull/15133) by [@sudz123](https://github.com/sudz123))
+"""


### PR DESCRIPTION
The PR number and author links are now only put on a separate line if the
change has blank lines, or a fenced code block.

Probably this should include other kinds of Markdown constructs like lists.

c.f. the notes from sympy/sympy#15133
