### PR TITLE
Remove references to "NO ENTRY" from the bot messages

### DIFF
--- a/sympy_bot/changelog.py
+++ b/sympy_bot/changelog.py
@@ -127,7 +127,7 @@ def get_changelog(pr_desc):
                 changelogs[header].append(line.strip())
     else:
         if not changelogs:
-            message_list += [f'* No release notes were detected. If there is no release notes entry, please write `NO ENTRY` in the PR description under `{BEGIN_RELEASE_NOTES}`.']
+            message_list += [f'* No release notes were detected. Please edit the PR description and write the release notes under `{BEGIN_RELEASE_NOTES}`.']
             status = False
 
     for header in changelogs:

--- a/sympy_bot/tests/test_get_changelog.py
+++ b/sympy_bot/tests/test_get_changelog.py
@@ -241,9 +241,8 @@ https://github.com/blog/1506-closing-issues-via-pull-requests .-->
 
 <!-- Write the release notes for this release below. See
 https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
-on how to write release notes. If there is no release notes entry for this PR,
-write "NO ENTRY". The bot will check your release notes automatically to see
-if they are formatted correctly. -->
+on how to write release notes. The bot will check your release notes
+automatically to see if they are formatted correctly. -->
 
 <!-- BEGIN RELEASE NOTES -->
 


### PR DESCRIPTION
NO ENTRY will only be mentioned on the guide on the wiki. This is to make it
less likely for people to just write "NO ENTRY" on PRs that need a release
note entry.

Fixes #30.