### PR TITLE
Require ## Changes as a header to start the release notes

### DIFF
--- a/sympy_bot/changelog.py
+++ b/sympy_bot/changelog.py
@@ -188,7 +188,15 @@ def update_release_notes(*, rel_notes_txt, changelogs, pr_number, authors):
     changelogs = changelogs.copy()
     authors = sorted(authors)
 
-    for line in rel_notes_txt.splitlines():
+    lines = iter(rel_notes_txt.splitlines())
+    for line in lines:
+        new_txt.append(line)
+        if line == "## Changes":
+            break
+    else:
+        raise RuntimeError("The `## Changes` header was not found in the release notes file.")
+
+    for line in lines:
         new_txt.append(line)
         line_header = line.lstrip(PREFIX)
         if line.startswith(PREFIX):

--- a/sympy_bot/tests/Release-Notes-for-1.2.md
+++ b/sympy_bot/tests/Release-Notes-for-1.2.md
@@ -79,7 +79,7 @@ code.
   rare, and wrapping can always be done by the user if necessary.
   [#14823](https://github.com/sympy/sympy/pull/14823)
 
-## Major Changes
+## Changes
 
 * algebras
   * add new algebras submodule

--- a/sympy_bot/webapp.py
+++ b/sympy_bot/webapp.py
@@ -130,6 +130,8 @@ There was an error getting the version from the `{RELEASE_FILE}` file. Please op
 
     if status:
         fake_release_notes = """
+## Changes
+
 ## Authors
 """
         release_notes_url = event.data['pull_request']['base']['repo']['html_url'] + '/wiki/' + release_notes_file[:-3] # Strip the .md for the URL
@@ -137,7 +139,7 @@ There was an error getting the version from the `{RELEASE_FILE}` file. Please op
         try:
             updated_fake_release_notes = update_release_notes(rel_notes_txt=fake_release_notes,
                 changelogs=changelogs, pr_number=number,
-                authors=users).replace('## Authors', '').strip()
+                authors=users).replace('## Authors', '').replace("## Changes", '').strip()
         except Exception as e:
             status = False
             status_message = "ERROR"


### PR DESCRIPTION
This prevents the bot from being confused by release notes formatted in the
same way under the backwards incompatible breaks section.

Fixes #35.