### PR TITLE
Add a check for bad bullet points in the entries

### DIFF
--- a/sympy_bot/changelog.py
+++ b/sympy_bot/changelog.py
@@ -122,6 +122,12 @@ def get_changelog(pr_desc):
                 # Multiline changelog
                 len_line_prefix = len(line) - len(line.lstrip())
                 changelogs[header][-1] += '\n' + ' '*(len_line_prefix - len(prefix)) + line.lstrip()
+            elif line and not is_bullet(line):
+                message_list += [
+                    f'* The line `{line}` does not appear to have a valid Markdown bullet. Make sure it starts with `* ` or `- ` with a space after the bullet.',
+                ]
+                status = False
+                break
             else:
                 prefix = ' '*(len(line) - len(line.lstrip()))
                 changelogs[header].append(line.strip())

--- a/sympy_bot/tests/test_get_changelog.py
+++ b/sympy_bot/tests/test_get_changelog.py
@@ -51,7 +51,7 @@ NO ENTRY
 NO ENTRY
 """
     status, message, changelogs = get_changelog(desc)
-    assert status
+    assert status, message
     assert "No release notes entry" in message
     assert not changelogs
 
@@ -251,4 +251,17 @@ automatically to see if they are formatted correctly. -->
     status, message, changelogs = get_changelog(desc)
     assert not status
     assert 'No release notes were found' in message
+    assert not changelogs
+
+def test_bad_bullet():
+    desc = r"""
+    <!-- BEGIN RELEASE NOTES -->
+* core
+  *`_atomic` can recurse into arguments
+<!-- END RELEASE NOTES -->
+"""
+    status, message, changelogs = get_changelog(desc)
+    assert not status
+    assert "*`_atomic` can recurse into arguments" in message
+    assert "Markdown bullet" in message
     assert not changelogs


### PR DESCRIPTION
If there isn't a space after the * or -, the wiki Markdown will not render the
line as a bulleted list item, but just render the * or - exactly.