### PR TITLE
Remove physics.unitsystems

### DIFF
--- a/sympy_bot/submodules.txt
+++ b/sympy_bot/submodules.txt
@@ -43,7 +43,6 @@ physics.quantum
 physics.secondquant
 physics.sho
 physics.units
-physics.unitsystems
 physics.vector
 physics.wigner
 


### PR DESCRIPTION
It has been removed from SymPy. https://github.com/sympy/sympy/pull/15287