### PR TITLE
Handle release notes bullets not being indented enough

### DIFF
--- a/sympy_bot/changelog.py
+++ b/sympy_bot/changelog.py
@@ -128,6 +128,12 @@ def get_changelog(pr_desc):
                 ]
                 status = False
                 break
+            elif line.strip() and len(line) - len(line.lstrip()) < 2:
+                message_list += [
+                    f"* The line `{line}` is not indented far enough. Please add at least two spaces before indented bullet points."
+                ]
+                status = False
+                break
             else:
                 prefix = ' '*(len(line) - len(line.lstrip()))
                 changelogs[header].append(line.strip())

--- a/sympy_bot/changelog.py
+++ b/sympy_bot/changelog.py
@@ -122,7 +122,7 @@ def get_changelog(pr_desc):
                 # Multiline changelog
                 len_line_prefix = len(line) - len(line.lstrip())
                 changelogs[header][-1] += '\n' + ' '*(len_line_prefix - len(prefix)) + line.lstrip()
-            elif line and not is_bullet(line):
+            elif line.strip() and not is_bullet(line):
                 message_list += [
                     f'* The line `{line}` does not appear to have a valid Markdown bullet. Make sure it starts with `* `, `- `, or `+ ` with a space after the bullet.',
                 ]

--- a/sympy_bot/tests/test_get_changelog.py
+++ b/sympy_bot/tests/test_get_changelog.py
@@ -35,7 +35,7 @@ NO ENTRY
     desc = """
 <!-- BEGIN RELEASE NOTES -->
 * solvers
- * new solver
+  * new solver
 
 NO ENTRY
 """
@@ -288,4 +288,17 @@ def test_bad_bullet():
     assert not status
     assert "*`_atomic` can recurse into arguments" in message
     assert "Markdown bullet" in message
+    assert not changelogs
+
+def test_bullet_not_indented_far_enough():
+    desc = r"""
+<!-- BEGIN RELEASE NOTES -->
+- solvers
+
+ - new solver
+"""
+    status, message, changelogs = get_changelog(desc)
+    assert not status
+    assert "indented" in message
+    assert "- new solver" in message
     assert not changelogs

--- a/sympy_bot/tests/test_get_changelog.py
+++ b/sympy_bot/tests/test_get_changelog.py
@@ -302,3 +302,16 @@ def test_bullet_not_indented_far_enough():
     assert "indented" in message
     assert "- new solver" in message
     assert not changelogs
+
+def test_trailing_whitespace():
+    desc = """
+<!-- BEGIN RELEASE NOTES -->
+- solvers \n\
+  \n\
+  - new solver \n\
+"""
+
+    status, message, changelogs = get_changelog(desc)
+    assert status, message
+    assert "good" in message
+    assert changelogs == {"solvers": ["- new solver"]}


### PR DESCRIPTION
They would parse just fine, but they don't format correctly in the pull
request message.