### PR TITLE
Improve test coverage

### DIFF
--- a/fix_authors.py
+++ b/fix_authors.py
@@ -75,7 +75,7 @@ def main():
             authors = format_authors(sorted(users, key=str.lower))
             print(f"Fixing authors for #{pr}: {authors}")
             release_re = rf'(?m)(\(\[#{pr}\]\(https://github.com/sympy/sympy/pull/{pr}\) by ).*\)$'
-            repl = rf'\1{authors}'
+            repl = rf'\1{authors})'
             release_notes, n = re.subn(release_re, repl, release_notes)
             if n == 0:
                 print(f"WARNING: Could not fix the authors for PR #{pr}.")

--- a/fix_authors.py
+++ b/fix_authors.py
@@ -64,8 +64,7 @@ def main():
             if commit['author']:
                 users.add(commit['author']['login'])
 
-        if not users:
-            users = {pull_request.json()['head']['user']['login']}
+        users.add(pull_request.json()['head']['user']['login'])
 
         pr_users[pr] = users
 

--- a/sympy_bot/changelog.py
+++ b/sympy_bot/changelog.py
@@ -139,7 +139,7 @@ def get_changelog(pr_desc):
                 changelogs[header].append(line.strip())
     else:
         if not changelogs:
-            message_list += [f'* No release notes were detected. Please edit the PR description and write the release notes under `{BEGIN_RELEASE_NOTES}`.']
+            message_list += [f'* No release notes were found. Please edit the PR description and write the release notes under `{BEGIN_RELEASE_NOTES}`.']
             status = False
 
     for header in changelogs:
@@ -157,7 +157,7 @@ def get_changelog(pr_desc):
     if not message_list:
         if not changelogs:
             status = False
-            message_list = ["*  No release notes were found. Please add release notes to the pull request description."]
+            message_list = [f'* No release notes were found. Please edit the PR description and write the release notes under `{BEGIN_RELEASE_NOTES}`.']
         else:
             message_list = ["Your release notes are in good order."]
     if not status:

--- a/sympy_bot/tests/test_get_changelog.py
+++ b/sympy_bot/tests/test_get_changelog.py
@@ -275,6 +275,7 @@ automatically to see if they are formatted correctly. -->
     status, message, changelogs = get_changelog(desc)
     assert not status
     assert 'No release notes were found' in message
+    assert "<!-- BEGIN RELEASE NOTES -->" in message
     assert not changelogs
 
 def test_bad_bullet():
@@ -315,3 +316,24 @@ def test_trailing_whitespace():
     assert status, message
     assert "good" in message
     assert changelogs == {"solvers": ["- new solver"]}
+
+def test_no_changelog():
+    desc = """
+<!-- BEGIN RELEASE NOTES -->
+
+<!-- END RELEASE NOTES -->
+    """
+    status, message, changelogs = get_changelog(desc)
+    assert not status
+    assert "No release notes were found" in message
+    assert "<!-- BEGIN RELEASE NOTES -->" in message
+    assert not changelogs
+
+    desc = """
+<!-- BEGIN RELEASE NOTES -->
+    """
+    status, message, changelogs = get_changelog(desc)
+    assert not status
+    assert "No release notes were found" in message
+    assert "<!-- BEGIN RELEASE NOTES -->" in message
+    assert not changelogs

--- a/sympy_bot/tests/test_webapp.py
+++ b/sympy_bot/tests/test_webapp.py
@@ -177,16 +177,19 @@ Note: This comment will be updated with the latest check if you edit the pull re
 
 
 @parametrize('action', ['closed', 'synchronize', 'edited'])
-async def test_closed_without_merging(action):
+@parametrize('merged', [True, False])
+async def test_no_action_on_closed_prs(action, merged):
+    if action == 'closed' and merged == True:
+        return
     gh = FakeGH()
     event_data = {
         'pull_request': {
             'number': 1,
             'state': 'closed',
-            'merged': False,
+            'merged': merged,
             },
         }
-    event_data['action'] = 'closed'
+    event_data['action'] = action
 
     event = _event(event_data)
 

--- a/sympy_bot/tests/test_webapp.py
+++ b/sympy_bot/tests/test_webapp.py
@@ -593,7 +593,7 @@ async def test_closed_with_merging(mocker, action):
     }]
     # Comments data
     assert patch_urls == [existing_comment_url, existing_comment_url]
-    'https://github.com/sympy/sympy/pulls/1(patch_data) == '
+    assert len(patch_data) == 2
     assert patch_data[0].keys() == {"body"}
     comment = patch_data[0]["body"]
     assert comment_body == comment
@@ -777,7 +777,7 @@ async def test_closed_with_merging_update_wiki_error(mocker, action, exception):
     }
     # Comments data
     assert patch_urls == [existing_comment_url]
-    'https://github.com/sympy/sympy/pulls/1(patch_data) == '
+    assert len(patch_data) == 1
     assert patch_data[0].keys() == {"body"}
     comment = patch_data[0]["body"]
     assert comment_body == comment

--- a/sympy_bot/tests/test_webapp.py
+++ b/sympy_bot/tests/test_webapp.py
@@ -245,7 +245,7 @@ async def test_status_good_new_comment(action):
         },
         # Test commits without a login
         {
-            'author': {},
+            'author': None,
             'commit': {
                 'message': "A good commit",
             },
@@ -373,7 +373,7 @@ async def test_status_good_existing_comment(action):
         },
         # Test commits without a login
         {
-            'author': {},
+            'author': None,
             'commit': {
                 'message': "A good commit",
             },
@@ -519,7 +519,7 @@ async def test_closed_with_merging(mocker, action):
         },
         # Test commits without a login
         {
-            'author': {},
+            'author': None,
             'commit': {
                 'message': "A good commit",
             },
@@ -680,7 +680,7 @@ async def test_closed_with_merging_no_entry(mocker, action):
         },
         # Test commits without a login
         {
-            'author': {},
+            'author': None,
             'commit': {
                 'message': "A good commit",
             },
@@ -832,7 +832,7 @@ async def test_closed_with_merging_update_wiki_error(mocker, action, exception):
         },
         # Test commits without a login
         {
-            'author': {},
+            'author': None,
             'commit': {
                 'message': "A good commit",
             },
@@ -1011,7 +1011,7 @@ async def test_closed_with_merging_bad_status_error(mocker, action):
         },
         # Test commits without a login
         {
-            'author': {},
+            'author': None,
             'commit': {
                 'message': "A good commit",
             },
@@ -1164,7 +1164,7 @@ async def test_status_bad_new_comment(action):
         },
         # Test commits without a login
         {
-            'author': {},
+            'author': None,
             'commit': {
                 'message': "A good commit",
             },
@@ -1288,7 +1288,7 @@ async def test_status_bad_existing_comment(action):
         },
         # Test commits without a login
         {
-            'author': {},
+            'author': None,
             'commit': {
                 'message': "A good commit",
             },
@@ -1421,7 +1421,7 @@ async def test_rate_limit_comment(action):
         },
         # Test commits without a login
         {
-            'author': {},
+            'author': None,
             'commit': {
                 'message': "A good commit",
             },
@@ -1539,7 +1539,7 @@ async def test_header_in_message(action):
         },
         # Test commits without a login
         {
-            'author': {},
+            'author': None,
             'commit': {
                 'message': "A good commit",
             },
@@ -1662,7 +1662,7 @@ async def test_bad_version_file(action):
         },
         # Test commits without a login
         {
-            'author': {},
+            'author': None,
             'commit': {
                 'message': "A good commit",
             },

--- a/sympy_bot/webapp.py
+++ b/sympy_bot/webapp.py
@@ -82,8 +82,8 @@ async def pull_request_comment(event, gh):
         if BEGIN_RELEASE_NOTES in message or END_RELEASE_NOTES in message:
             header_in_message = commit['sha']
 
-    if not users:
-        users = {event.data['pull_request']['head']['user']['login']}
+
+    users.add(event.data['pull_request']['head']['user']['login'])
 
     users = sorted(users)
     contents_url = event.data['pull_request']['base']['repo']['contents_url']


### PR DESCRIPTION
See https://github.com/sympy/sympy-bot/issues/47. Coverage may still be improvable in some places. 

Also fixes some bugs:

- fix_authors.py wasn't including a closing parenthesis
- The bot now always includes the person who opened the pull request in the authors list. Previously this was only done if all the commits had no login information, but if there were commits from someone else as well, it wasn't included. 
- Minor error message improvement when there are no release notes found