### PR TITLE
Don't make the entry multiline if it has ``` but no newlines

### DIFF
--- a/sympy_bot/changelog.py
+++ b/sympy_bot/changelog.py
@@ -188,7 +188,7 @@ def format_change(change, pr_number, authors):
     authors_info = format_authors(authors)
 
     indent = ' '
-    if '\n\n' in change or "```" in change:
+    if '\n\n' in change or ("```" in change and '\n' in change):
         change += '\n\n'
         indent = '  '
 

--- a/sympy_bot/tests/test_get_changelog.py
+++ b/sympy_bot/tests/test_get_changelog.py
@@ -165,6 +165,20 @@ def test_multiline():
         'core': ['* core change'],
     }
 
+def test_threebackticks_not_multiline():
+    desc = """
+<!-- BEGIN RELEASE NOTES -->
+* crypto
+  * added ```rot13``` and ```atbash``` ciphers
+<!-- END RELEASE NOTES -->
+"""
+    status, message, changelogs = get_changelog(desc)
+    assert status
+    assert "good" in message
+    assert changelogs == {
+        'crypto': ['* added ```rot13``` and ```atbash``` ciphers'],
+        }
+
 def test_multiple_multiline():
     # from sympy/sympy#14758, see #14
     desc = """


### PR DESCRIPTION
See for instance https://github.com/sympy/sympy/pull/16516, where the PR
number and author are unnecessarily put on a separate line because the author
used \```code``` for inline code instead of just \`code`.