### PR TITLE
Comment about files that are added or deleted

### DIFF
--- a/sympy_bot/tests/test_webapp.py
+++ b/sympy_bot/tests/test_webapp.py
@@ -122,6 +122,8 @@ comments_url = 'https://api.github.com/repos/sympy/sympy/pulls/1/comments'
 commits_url = 'https://api.github.com/repos/sympy/sympy/pulls/1/commits'
 contents_url = 'https://api.github.com/repos/sympy/sympy/contents/{+path}'
 sha = 'a109f824f4cb2b1dd97cf832f329d59da00d609a'
+commit_url_template = 'https://api.github.com/repos/sympy/sympy/commits/{sha}'
+commit_url = commit_url_template.format(sha=sha)
 version_url_template = 'https://api.github.com/repos/sympy/sympy/contents/sympy/release.py?ref={ref}'
 version_url = version_url_template.format(ref='master')
 html_url = "https://github.com/sympy/sympy"
@@ -236,6 +238,7 @@ async def test_status_good_new_comment(action):
                 'message': "A good commit",
             },
             'sha': sha,
+            'url': commit_url,
         },
         {
             'author': {
@@ -245,6 +248,7 @@ async def test_status_good_new_comment(action):
                 'message': "A good commit",
             },
             'sha': sha,
+            'url': commit_url,
         },
         # Test commits without a login
         {
@@ -253,8 +257,17 @@ async def test_status_good_new_comment(action):
                 'message': "A good commit",
             },
             'sha': sha,
+            'url': commit_url,
         },
     ]
+
+    commit = {
+        'files': [
+            {
+                'status': 'modified',
+            },
+        ]
+    }
 
     # No comment from sympy-bot
     comments = [
@@ -281,6 +294,7 @@ async def test_status_good_new_comment(action):
 
     getitem = {
         version_url: version_file,
+        commit_url: commit,
     }
     post = {
         comments_url: {
@@ -303,7 +317,7 @@ async def test_status_good_new_comment(action):
     patch_data = gh.patch_data
 
     assert getiter_urls == list(getiter)
-    assert getitem_urls == list(getitem)
+    assert getitem_urls == [commit_url]*len(commits) + [version_url]
     assert post_urls == [comments_url, statuses_url]
     assert len(post_data) == 2
     # Comments data
@@ -355,7 +369,6 @@ async def test_status_good_existing_comment(action):
         'action': action,
     }
 
-
     commits = [
         {
             'author': {
@@ -365,6 +378,7 @@ async def test_status_good_existing_comment(action):
                 'message': "A good commit",
             },
             'sha': sha,
+            'url': commit_url,
         },
         {
             'author': {
@@ -374,6 +388,7 @@ async def test_status_good_existing_comment(action):
                 'message': "A good commit",
             },
             'sha': sha,
+            'url': commit_url,
         },
         # Test commits without a login
         {
@@ -382,8 +397,17 @@ async def test_status_good_existing_comment(action):
                 'message': "A good commit",
             },
             'sha': sha,
+            'url': commit_url,
         },
     ]
+
+    commit = {
+        'files': [
+            {
+                'status': 'modified',
+            },
+        ]
+    }
 
     # Has comment from sympy-bot
     comments = [
@@ -392,16 +416,19 @@ async def test_status_good_existing_comment(action):
                 'login': 'sympy-bot',
             },
             'url': existing_comment_url,
+            'body': comment_body,
         },
         {
             'user': {
                 'login': 'asmeurer',
             },
+            'body': "comment",
         },
         {
             'user': {
                 'login': 'certik',
             },
+            "body": "comment",
         },
     ]
 
@@ -416,6 +443,7 @@ async def test_status_good_existing_comment(action):
 
     getitem = {
         version_url: version_file,
+        commit_url: commit,
     }
     post = {
         statuses_url: {},
@@ -441,7 +469,7 @@ async def test_status_good_existing_comment(action):
     patch_data = gh.patch_data
 
     assert getiter_urls == list(getiter)
-    assert getitem_urls == list(getitem)
+    assert getitem_urls == [commit_url]*len(commits) + [version_url]
     assert post_urls == [statuses_url]
     # Statuses data
     assert post_data == [{
@@ -512,6 +540,7 @@ async def test_closed_with_merging(mocker, action):
                 'message': "A good commit",
             },
             'sha': sha,
+            'url': commit_url,
         },
         {
             'author': {
@@ -521,6 +550,7 @@ async def test_closed_with_merging(mocker, action):
                 'message': "A good commit",
             },
             'sha': sha,
+            'url': commit_url,
         },
         # Test commits without a login
         {
@@ -529,8 +559,17 @@ async def test_closed_with_merging(mocker, action):
                 'message': "A good commit",
             },
             'sha': sha,
+            'url': commit_url,
         },
     ]
+
+    commit = {
+        'files': [
+            {
+                'status': 'modified',
+            },
+        ]
+    }
 
     # Has comment from sympy-bot
     comments = [
@@ -539,16 +578,19 @@ async def test_closed_with_merging(mocker, action):
                 'login': 'sympy-bot',
             },
             'url': existing_comment_url,
+            'body': comment_body,
         },
         {
             'user': {
                 'login': 'asmeurer',
             },
+            'body': "comment",
         },
         {
             'user': {
                 'login': 'certik',
             },
+            'body': "comment",
         },
     ]
 
@@ -563,6 +605,7 @@ async def test_closed_with_merging(mocker, action):
 
     getitem = {
         version_url: version_file,
+        commit_url: commit,
     }
     post = {
         statuses_url: {},
@@ -590,7 +633,7 @@ async def test_closed_with_merging(mocker, action):
     patch_data = gh.patch_data
 
     assert getiter_urls == list(getiter), getiter_urls
-    assert getitem_urls == list(getitem)
+    assert getitem_urls == [commit_url]*len(commits) + [version_url]
     assert post_urls == [statuses_url]
     # Statuses data
     assert post_data == [{
@@ -664,6 +707,13 @@ async def test_closed_with_merging_no_entry(mocker, action):
         'action': action,
     }
 
+    commit = {
+        'files': [
+            {
+                'status': 'modified',
+            },
+        ]
+    }
 
     commits = [
         {
@@ -674,6 +724,7 @@ async def test_closed_with_merging_no_entry(mocker, action):
                 'message': "A good commit",
             },
             'sha': sha,
+            'url': commit_url,
         },
         {
             'author': {
@@ -683,6 +734,7 @@ async def test_closed_with_merging_no_entry(mocker, action):
                 'message': "A good commit",
             },
             'sha': sha,
+            'url': commit_url,
         },
         # Test commits without a login
         {
@@ -691,6 +743,7 @@ async def test_closed_with_merging_no_entry(mocker, action):
                 'message': "A good commit",
             },
             'sha': sha,
+            'url': commit_url,
         },
     ]
 
@@ -701,16 +754,19 @@ async def test_closed_with_merging_no_entry(mocker, action):
                 'login': 'sympy-bot',
             },
             'url': existing_comment_url,
+            'body': comment_body,
         },
         {
             'user': {
                 'login': 'asmeurer',
             },
+            'body': "comment",
         },
         {
             'user': {
                 'login': 'certik',
             },
+            'body': "comment",
         },
     ]
 
@@ -725,6 +781,7 @@ async def test_closed_with_merging_no_entry(mocker, action):
 
     getitem = {
         version_url: version_file,
+        commit_url: commit,
     }
     post = {
         statuses_url: {},
@@ -752,7 +809,7 @@ async def test_closed_with_merging_no_entry(mocker, action):
     patch_data = gh.patch_data
 
     assert getiter_urls == list(getiter), getiter_urls
-    assert getitem_urls == list(getitem)
+    assert getitem_urls == [commit_url]*len(commits) + [version_url]
     assert post_urls == [statuses_url]
     # Statuses data
     assert post_data == [{
@@ -827,6 +884,7 @@ async def test_closed_with_merging_update_wiki_error(mocker, action, exception):
                 'message': "A good commit",
             },
             'sha': sha,
+            'url': commit_url,
         },
         {
             'author': {
@@ -836,6 +894,7 @@ async def test_closed_with_merging_update_wiki_error(mocker, action, exception):
                 'message': "A good commit",
             },
             'sha': sha,
+            'url': commit_url,
         },
         # Test commits without a login
         {
@@ -844,8 +903,17 @@ async def test_closed_with_merging_update_wiki_error(mocker, action, exception):
                 'message': "A good commit",
             },
             'sha': sha,
+            'url': commit_url,
         },
     ]
+
+    commit = {
+        'files': [
+            {
+                'status': 'modified',
+            },
+        ]
+    }
 
     # Has comment from sympy-bot
     comments = [
@@ -854,16 +922,19 @@ async def test_closed_with_merging_update_wiki_error(mocker, action, exception):
                 'login': 'sympy-bot',
             },
             'url': existing_comment_url,
+            'body': comment_body,
         },
         {
             'user': {
                 'login': 'asmeurer',
             },
+            'body': "comment",
         },
         {
             'user': {
                 'login': 'certik',
             },
+            'body': "comment",
         },
     ]
 
@@ -878,6 +949,7 @@ async def test_closed_with_merging_update_wiki_error(mocker, action, exception):
 
     getitem = {
         version_url: version_file,
+        commit_url: commit,
     }
     post = {
         statuses_url: {},
@@ -909,7 +981,7 @@ async def test_closed_with_merging_update_wiki_error(mocker, action, exception):
     patch_data = gh.patch_data
 
     assert getiter_urls == list(getiter), getiter_urls
-    assert getitem_urls == list(getitem)
+    assert getitem_urls == [commit_url]*len(commits) + [version_url]
     assert post_urls == [statuses_url, comments_url, statuses_url]
     # Statuses data
     assert len(post_data) == 3
@@ -1007,6 +1079,7 @@ async def test_closed_with_merging_bad_status_error(mocker, action):
                 'message': "A good commit",
             },
             'sha': sha,
+            'url': commit_url,
         },
         {
             'author': {
@@ -1016,6 +1089,7 @@ async def test_closed_with_merging_bad_status_error(mocker, action):
                 'message': "A good commit",
             },
             'sha': sha,
+            'url': commit_url,
         },
         # Test commits without a login
         {
@@ -1024,8 +1098,17 @@ async def test_closed_with_merging_bad_status_error(mocker, action):
                 'message': "A good commit",
             },
             'sha': sha,
+            'url': commit_url,
         },
     ]
+
+    commit = {
+        'files': [
+            {
+                'status': 'modified',
+            },
+        ]
+    }
 
     # Has comment from sympy-bot
     comments = [
@@ -1034,16 +1117,19 @@ async def test_closed_with_merging_bad_status_error(mocker, action):
                 'login': 'sympy-bot',
             },
             'url': existing_comment_url,
+            'body': comment_body,
         },
         {
             'user': {
                 'login': 'asmeurer',
             },
+            'body': "comment",
         },
         {
             'user': {
                 'login': 'certik',
             },
+            'body': "comment",
         },
     ]
 
@@ -1052,7 +1138,9 @@ async def test_closed_with_merging_bad_status_error(mocker, action):
         comments_url: comments,
     }
 
-    getitem = {}
+    getitem = {
+        commit_url: commit,
+    }
     post = {
         statuses_url: {},
         comments_url: {
@@ -1082,7 +1170,7 @@ async def test_closed_with_merging_bad_status_error(mocker, action):
     patch_data = gh.patch_data
 
     assert getiter_urls == list(getiter), getiter_urls
-    assert getitem_urls == list(getitem)
+    assert getitem_urls == [commit_url]*len(commits)
     assert post_urls == [statuses_url, comments_url, statuses_url]
     # Statuses data
     assert len(post_data) == 3
@@ -1161,6 +1249,7 @@ async def test_status_bad_new_comment(action):
                 'message': "A good commit",
             },
             'sha': sha,
+            'url': commit_url,
         },
         {
             'author': {
@@ -1170,6 +1259,7 @@ async def test_status_bad_new_comment(action):
                 'message': "A good commit",
             },
             'sha': sha,
+            'url': commit_url,
         },
         # Test commits without a login
         {
@@ -1178,8 +1268,17 @@ async def test_status_bad_new_comment(action):
                 'message': "A good commit",
             },
             'sha': sha,
+            'url': commit_url,
         },
     ]
+
+    commit = {
+        'files': [
+            {
+                'status': 'modified',
+            },
+        ]
+    }
 
     # No comment from sympy-bot
     comments = [
@@ -1187,11 +1286,13 @@ async def test_status_bad_new_comment(action):
             'user': {
                 'login': 'asmeurer',
             },
+            'body': "comment",
         },
         {
             'user': {
                 'login': 'certik',
             },
+            'body': "comment",
         },
     ]
 
@@ -1200,7 +1301,9 @@ async def test_status_bad_new_comment(action):
         comments_url: comments,
     }
 
-    getitem = {}
+    getitem = {
+        commit_url: commit,
+    }
     post = {
         comments_url: {
             'html_url': comment_html_url,
@@ -1222,7 +1325,7 @@ async def test_status_bad_new_comment(action):
     patch_data = gh.patch_data
 
     assert getiter_urls == list(getiter)
-    assert getitem_urls == list(getitem)
+    assert getitem_urls == [commit_url]*len(commits)
     assert post_urls == [comments_url, statuses_url]
     assert len(post_data) == 2
     # Comments data
@@ -1286,6 +1389,7 @@ async def test_status_bad_existing_comment(action):
                 'message': "A good commit",
             },
             'sha': sha,
+            'url': commit_url,
         },
         {
             'author': {
@@ -1295,6 +1399,7 @@ async def test_status_bad_existing_comment(action):
                 'message': "A good commit",
             },
             'sha': sha,
+            'url': commit_url,
         },
         # Test commits without a login
         {
@@ -1303,8 +1408,17 @@ async def test_status_bad_existing_comment(action):
                 'message': "A good commit",
             },
             'sha': sha,
+            'url': commit_url,
         },
     ]
+
+    commit = {
+        'files': [
+            {
+                'status': 'modified',
+            },
+        ]
+    }
 
     # Has comment from sympy-bot
     comments = [
@@ -1313,16 +1427,19 @@ async def test_status_bad_existing_comment(action):
                 'login': 'sympy-bot',
             },
             'url': existing_comment_url,
+            'body': comment_body,
         },
         {
             'user': {
                 'login': 'asmeurer',
             },
+            'body': "comment",
         },
         {
             'user': {
                 'login': 'certik',
             },
+            'body': "comment",
         },
     ]
 
@@ -1331,7 +1448,9 @@ async def test_status_bad_existing_comment(action):
         comments_url: comments,
     }
 
-    getitem = {}
+    getitem = {
+        commit_url: commit,
+    }
     post = {
         statuses_url: {},
     }
@@ -1356,7 +1475,7 @@ async def test_status_bad_existing_comment(action):
     patch_data = gh.patch_data
 
     assert getiter_urls == list(getiter)
-    assert getitem_urls == list(getitem)
+    assert getitem_urls == [commit_url]*len(commits)
     assert post_urls == [statuses_url]
     # Statuses data
     assert post_data == [{
@@ -1420,6 +1539,7 @@ async def test_rate_limit_comment(action):
                 'message': "A good commit",
             },
             'sha': sha,
+            'url': commit_url,
         },
         {
             'author': {
@@ -1429,6 +1549,7 @@ async def test_rate_limit_comment(action):
                 'message': "A good commit",
             },
             'sha': sha,
+            'url': commit_url,
         },
         # Test commits without a login
         {
@@ -1437,8 +1558,17 @@ async def test_rate_limit_comment(action):
                 'message': "A good commit",
             },
             'sha': sha,
+            'url': commit_url,
         },
     ]
+
+    commit = {
+        'files': [
+            {
+                'status': 'modified',
+            },
+        ]
+    }
 
     # No comment from sympy-bot
     comments = [
@@ -1446,11 +1576,13 @@ async def test_rate_limit_comment(action):
             'user': {
                 'login': 'asmeurer',
             },
+            'body': "comment",
         },
         {
             'user': {
                 'login': 'certik',
             },
+            "body": "comment",
         },
     ]
 
@@ -1465,6 +1597,7 @@ async def test_rate_limit_comment(action):
 
     getitem = {
         version_url: version_file,
+        commit_url: commit,
     }
     post = {
         comments_url: {
@@ -1524,7 +1657,7 @@ async def test_header_in_message(action):
         'action': action,
     }
 
-
+    sha_1 = '174b8b37bc33e9eb29e710a233190d02a13bdb54'
     commits = [
         {
             'author': {
@@ -1538,7 +1671,8 @@ async def test_header_in_message(action):
 <!-- END RELEASE NOTES -->
 """
             },
-            'sha': '174b8b37bc33e9eb29e710a233190d02a13bdb54',
+            'sha': sha_1,
+            'url': commit_url_template.format(sha=sha_1)
         },
         {
             'author': {
@@ -1548,6 +1682,7 @@ async def test_header_in_message(action):
                 'message': "A good commit",
             },
             'sha': sha,
+            'url': commit_url,
         },
         # Test commits without a login
         {
@@ -1556,8 +1691,17 @@ async def test_header_in_message(action):
                 'message': "A good commit",
             },
             'sha': sha,
+            'url': commit_url,
         },
     ]
+
+    commit = {
+        'files': [
+            {
+                'status': 'modified',
+            },
+        ]
+    }
 
     # No comment from sympy-bot
     comments = [
@@ -1565,11 +1709,13 @@ async def test_header_in_message(action):
             'user': {
                 'login': 'asmeurer',
             },
+            'body': "comment",
         },
         {
             'user': {
                 'login': 'certik',
             },
+            'body': "comment",
         },
     ]
 
@@ -1578,7 +1724,10 @@ async def test_header_in_message(action):
         comments_url: comments,
     }
 
-    getitem = {}
+    getitem = {
+        commit_url: commit,
+        commit_url_template.format(sha=sha_1): commit,
+    }
     post = {
         comments_url: {
             'html_url': comment_html_url,
@@ -1601,7 +1750,7 @@ async def test_header_in_message(action):
 
     # The rest is already tested in test_status_good_new_comment
     assert getiter_urls == list(getiter)
-    assert getitem_urls == list(getitem)
+    assert getitem_urls == [commit_url_template.format(sha=sha_1)] + 2*[commit_url]
     assert post_urls == [comments_url, statuses_url]
     assert len(post_data) == 2
     # Comments data
@@ -1612,7 +1761,7 @@ async def test_header_in_message(action):
     assert "error" not in comment
     assert "https://github.com/sympy/sympy-bot" in comment
     assert "good order" not in comment
-    assert "174b8b37bc33e9eb29e710a233190d02a13bdb54" in comment
+    assert sha_1 in comment
     assert "<!-- BEGIN RELEASE NOTES -->" in comment
     assert "<!-- END RELEASE NOTES -->" in comment
     # Statuses data
@@ -1663,6 +1812,7 @@ async def test_bad_version_file(action):
                 'message': "A good commit",
             },
             'sha': sha,
+            'url': commit_url,
         },
         {
             'author': {
@@ -1672,6 +1822,7 @@ async def test_bad_version_file(action):
                 'message': "A good commit",
             },
             'sha': sha,
+            'url': commit_url,
         },
         # Test commits without a login
         {
@@ -1680,8 +1831,17 @@ async def test_bad_version_file(action):
                 'message': "A good commit",
             },
             'sha': sha,
+            'url': commit_url,
         },
     ]
+
+    commit = {
+        'files': [
+            {
+                'status': 'modified',
+            },
+        ]
+    }
 
     # No comment from sympy-bot
     comments = [
@@ -1708,6 +1868,7 @@ async def test_bad_version_file(action):
 
     getitem = {
         version_url: version_file,
+        commit_url: commit,
     }
     post = {
         comments_url: {
@@ -1730,7 +1891,7 @@ async def test_bad_version_file(action):
     patch_data = gh.patch_data
 
     assert getiter_urls == list(getiter)
-    assert getitem_urls == list(getitem)
+    assert getitem_urls == [commit_url]*len(commits) + [version_url]
     assert post_urls == [comments_url, statuses_url]
     assert len(post_data) == 2
     # Comments data
@@ -1793,8 +1954,18 @@ async def test_no_user_logins_in_commits(action, include_extra):
                 'message': "A good commit",
             },
             'sha': sha,
+            'url': commit_url,
         },
     ]
+
+    commit = {
+        'files': [
+            {
+                'status': 'modified',
+            },
+        ]
+    }
+
     if include_extra:
         commits += [
             {
@@ -1805,6 +1976,7 @@ async def test_no_user_logins_in_commits(action, include_extra):
                     'message': "A good commit",
                 },
                 'sha': sha,
+                'url': commit_url,
             },
         ]
 
@@ -1814,11 +1986,13 @@ async def test_no_user_logins_in_commits(action, include_extra):
             'user': {
                 'login': 'asmeurer',
             },
+            'body': "comment",
         },
         {
             'user': {
                 'login': 'certik',
             },
+            'body': "comment",
         },
     ]
 
@@ -1833,6 +2007,7 @@ async def test_no_user_logins_in_commits(action, include_extra):
 
     getitem = {
         version_url: version_file,
+        commit_url: commit,
     }
     post = {
         comments_url: {
@@ -1855,7 +2030,7 @@ async def test_no_user_logins_in_commits(action, include_extra):
     patch_data = gh.patch_data
 
     assert getiter_urls == list(getiter)
-    assert getitem_urls == list(getitem)
+    assert getitem_urls == [commit_url]*len(commits) + [version_url]
     assert post_urls == [comments_url, statuses_url]
     assert len(post_data) == 2
     # Comments data
@@ -1920,6 +2095,7 @@ async def test_status_good_new_comment_other_base(action):
                 'message': "A good commit",
             },
             'sha': sha,
+            'url': commit_url,
         },
         {
             'author': {
@@ -1929,6 +2105,7 @@ async def test_status_good_new_comment_other_base(action):
                 'message': "A good commit",
             },
             'sha': sha,
+            'url': commit_url,
         },
         # Test commits without a login
         {
@@ -1937,8 +2114,17 @@ async def test_status_good_new_comment_other_base(action):
                 'message': "A good commit",
             },
             'sha': sha,
+            'url': commit_url,
         },
     ]
+
+    commit = {
+        'files': [
+            {
+                'status': 'modified',
+            },
+        ]
+    }
 
     # No comment from sympy-bot
     comments = [
@@ -1965,6 +2151,7 @@ async def test_status_good_new_comment_other_base(action):
 
     getitem = {
         version_url_template.format(ref='1.4'): version_file,
+        commit_url: commit,
     }
     post = {
         comments_url: {
@@ -1987,7 +2174,7 @@ async def test_status_good_new_comment_other_base(action):
     patch_data = gh.patch_data
 
     assert getiter_urls == list(getiter)
-    assert getitem_urls == list(getitem)
+    assert getitem_urls == [commit_url]*len(commits) + [version_url_template.format(ref='1.4')]
     assert post_urls == [comments_url, statuses_url]
     assert len(post_data) == 2
     # Comments data

--- a/sympy_bot/tests/test_webapp.py
+++ b/sympy_bot/tests/test_webapp.py
@@ -70,17 +70,19 @@ class FakeGH:
 
     """
     def __init__(self, *, getitem=None, getiter=None, rate_limit=None,
-        post=None, patch=None):
+        post=None, patch=None, delete=None):
         self._getitem_return = getitem
         self._getiter_return = getiter
         self._post_return = post
         self._patch_return = patch
+        self._delete_return = delete
         self.getiter_urls = []
         self.getitem_urls = []
         self.post_urls = []
         self.post_data = []
         self.patch_urls = []
         self.patch_data = []
+        self.delete_urls = []
         self.rate_limit = rate_limit or FakeRateLimit()
 
     async def getitem(self, url):
@@ -102,6 +104,10 @@ class FakeGH:
         self.patch_data.append(data)
         return self._patch_return[url]
 
+    async def delete(self, url):
+        self.delete_urls.append(url)
+        return self._delete_return[url]
+
 def _assert_gh_is_empty(gh):
     assert gh._getitem_return == None
     assert gh._getiter_return == None
@@ -112,6 +118,7 @@ def _assert_gh_is_empty(gh):
     assert gh.post_data == []
     assert gh.patch_urls == []
     assert gh.patch_data == []
+    assert gh.delete_urls == []
 
 def _event(data):
     return sansio.Event(data, event='pull_request', delivery_id='1')

--- a/sympy_bot/tests/test_webapp.py
+++ b/sympy_bot/tests/test_webapp.py
@@ -136,8 +136,10 @@ version_url = version_url_template.format(ref='master')
 html_url = "https://github.com/sympy/sympy"
 wiki_url = "https://github.com/sympy/sympy.wiki"
 comment_html_url = 'https://github.com/sympy/sympy/pulls/1#issuecomment-1'
+comment_html_url2 = 'https://github.com/sympy/sympy/pulls/1#issuecomment-2'
 statuses_url = "https://api.github.com/repos/sympy/sympy/statuses/4a09f9f253c7372ec857774b1fe114b1266013fe"
 existing_comment_url = "https://api.github.com/repos/sympy/sympy/issues/comments/1"
+existing_added_deleted_comment_url = "https://api.github.com/repos/sympy/sympy/issues/comments/2"
 pr_number = 1
 
 valid_PR_description = """
@@ -186,6 +188,23 @@ Note: This comment will be updated with the latest check if you edit the pull re
 </details><p>
 """
 
+added_deleted_comment_body = """\
+### \U0001f7e0
+
+Hi, I am the [SymPy bot](https://github.com/sympy/sympy-bot) (version not found!). I've noticed that some of your commits add or delete files. Since this is sometimes done unintentionally, I wanted to alert you about it.
+
+This is an experimental feature of SymPy Bot. If you have any feedback on it, please comment at https://github.com/sympy/sympy-bot/issues/75.
+
+The following commits **add new files**:
+* 174b8b37bc33e9eb29e710a233190d02a13bdb54:
+  - `file1`
+
+The following commits **delete files**:
+* a109f824f4cb2b1dd97cf832f329d59da00d609a:
+  - `file1`
+
+If these files were added/deleted on purpose, you can ignore this message.
+"""
 
 @parametrize('action', ['closed', 'synchronize', 'edited'])
 @parametrize('merged', [True, False])
@@ -2206,3 +2225,514 @@ async def test_status_good_new_comment_other_base(action):
     }
     assert patch_urls == []
     assert patch_data == []
+
+@parametrize('action', ['opened', 'reopened', 'synchronize', 'edited'])
+async def test_added_deleted_new_comment(action):
+    # Based on test_status_good_existing_comment
+    event_data = {
+        'pull_request': {
+            'number': 1,
+            'state': 'open',
+            'merged': False,
+            'comments_url': comments_url,
+            'commits_url': commits_url,
+            'head': {
+                'user': {
+                    'login': 'asmeurer',
+                    },
+            },
+            'base': {
+                'repo': {
+                    'contents_url': contents_url,
+                    'html_url': html_url,
+                },
+                'ref': 'master',
+            },
+            'body': valid_PR_description,
+            'statuses_url': statuses_url,
+        },
+        'action': action,
+    }
+
+    sha_1 = '174b8b37bc33e9eb29e710a233190d02a13bdb54'
+    sha_2 = 'aef484a1d46bb5389f1709d78e39126d9cb8599f'
+    sha_3 = sha
+
+    commits = [
+        {
+            'author': {
+                'login': 'asmeurer',
+            },
+            'commit': {
+                'message': "Adds file1"
+            },
+            'sha': sha_1,
+            'url': commit_url_template.format(sha=sha_1)
+        },
+        {
+            'author': {
+                'login': 'asmeurer',
+            },
+            'commit': {
+                'message': "Modifies file1",
+            },
+            'sha': sha_2,
+            'url': commit_url_template.format(sha=sha_2),
+        },
+        {
+            'author': {
+                'login': 'asmeurer',
+            },
+            'commit': {
+                'message': "Deletes file1",
+            },
+            'sha': sha_3,
+            'url': commit_url_template.format(sha=sha_3),
+        },
+    ]
+
+    commit_add = {
+        'sha': sha_1,
+        'files': [
+            {
+                'filename': 'file1',
+                'status': 'added',
+            },
+        ]
+    }
+
+    commit_modify = {
+        'sha': sha_2,
+        'files': [
+            {
+                'filename': 'file1',
+                'status': 'modified',
+            },
+        ]
+    }
+
+    commit_delete = {
+        'sha': sha_3,
+        'files': [
+            {
+                'filename': 'file1',
+                'status': 'removed',
+            },
+        ]
+    }
+
+    comments = [
+        {
+            'user': {
+                'login': 'sympy-bot',
+            },
+            'url': existing_comment_url,
+            'body': comment_body,
+        },
+        {
+            'user': {
+                'login': 'asmeurer',
+            },
+            'body': "comment",
+        },
+        {
+            'user': {
+                'login': 'certik',
+            },
+            'body': "comment",
+        },
+    ]
+
+    version_file = {
+        'content': base64.b64encode(b'__version__ = "1.2.1.dev"\n'),
+    }
+
+    getiter = {
+        commits_url: commits,
+        comments_url: comments,
+    }
+
+    getitem = {
+        commit_url_template.format(sha=sha_1): commit_add,
+        commit_url_template.format(sha=sha_2): commit_modify,
+        commit_url_template.format(sha=sha_3): commit_delete,
+        version_url: version_file,
+    }
+    post = {
+        comments_url: {
+            'html_url': comment_html_url,
+        },
+        statuses_url: {},
+    }
+    patch = {
+        existing_comment_url: {
+            'html_url': comment_html_url,
+        },
+    }
+
+    event = _event(event_data)
+
+    gh = FakeGH(getiter=getiter, getitem=getitem, post=post, patch=patch)
+
+    await router.dispatch(event, gh)
+
+    getitem_urls = gh.getitem_urls
+    getiter_urls = gh.getiter_urls
+    post_urls = gh.post_urls
+    post_data = gh.post_data
+    patch_urls = gh.patch_urls
+
+    # The rest is already tested in test_status_good_new_comment
+    assert getiter_urls == list(getiter)
+    assert getitem_urls == list(getitem)
+    assert post_urls == [comments_url, statuses_url]
+    assert patch_urls == [existing_comment_url]
+    assert len(post_data) == 2
+    # Comments data
+    assert post_data[0].keys() == {"body"}
+    comment = post_data[0]["body"]
+    assert ":white_check_mark:" not in comment
+    assert ":x:" not in comment
+    assert "\U0001f7e0" in comment
+    assert "error" not in comment
+    assert "add new files" in comment
+    assert "delete files" in comment
+    assert "https://github.com/sympy/sympy-bot" in comment
+    assert sha_1 in comment
+    assert sha_2 not in comment
+    assert sha_3 in comment
+    assert "`file1`" in comment
+    assert "<!-- BEGIN RELEASE NOTES -->" not in comment
+    assert "<!-- END RELEASE NOTES -->" not in comment
+
+
+@parametrize('action', ['opened', 'reopened', 'synchronize', 'edited'])
+async def test_added_deleted_existing_comment(action):
+    # Based on test_status_good_existing_comment
+    event_data = {
+        'pull_request': {
+            'number': 1,
+            'state': 'open',
+            'merged': False,
+            'comments_url': comments_url,
+            'commits_url': commits_url,
+            'head': {
+                'user': {
+                    'login': 'asmeurer',
+                    },
+            },
+            'base': {
+                'repo': {
+                    'contents_url': contents_url,
+                    'html_url': html_url,
+                },
+                'ref': 'master',
+            },
+            'body': valid_PR_description,
+            'statuses_url': statuses_url,
+        },
+        'action': action,
+    }
+
+    sha_1 = '174b8b37bc33e9eb29e710a233190d02a13bdb54'
+    sha_2 = 'aef484a1d46bb5389f1709d78e39126d9cb8599f'
+    sha_3 = sha
+
+    commits = [
+        {
+            'author': {
+                'login': 'asmeurer',
+            },
+            'commit': {
+                'message': "Adds file1"
+            },
+            'sha': sha_1,
+            'url': commit_url_template.format(sha=sha_1)
+        },
+        {
+            'author': {
+                'login': 'asmeurer',
+            },
+            'commit': {
+                'message': "Modifies file1",
+            },
+            'sha': sha_2,
+            'url': commit_url_template.format(sha=sha_2),
+        },
+        {
+            'author': {
+                'login': 'asmeurer',
+            },
+            'commit': {
+                'message': "Deletes file1",
+            },
+            'sha': sha_3,
+            'url': commit_url_template.format(sha=sha_3),
+        },
+    ]
+
+    commit_add = {
+        'sha': sha_1,
+        'files': [
+            {
+                'filename': 'file1',
+                'status': 'added',
+            },
+        ]
+    }
+
+    commit_modify = {
+        'sha': sha_2,
+        'files': [
+            {
+                'filename': 'file1',
+                'status': 'modified',
+            },
+        ]
+    }
+
+    commit_delete = {
+        'sha': sha_3,
+        'files': [
+            {
+                'filename': 'file1',
+                'status': 'removed',
+            },
+        ]
+    }
+
+    comments = [
+        {
+            'user': {
+                'login': 'sympy-bot',
+            },
+            'url': existing_comment_url,
+            'body': comment_body,
+        },
+        {
+            'user': {
+                'login': 'sympy-bot',
+            },
+            'url': existing_added_deleted_comment_url,
+            'body': added_deleted_comment_body,
+        },
+        {
+            'user': {
+                'login': 'asmeurer',
+            },
+            'body': "comment",
+        },
+        {
+            'user': {
+                'login': 'certik',
+            },
+            'body': "comment",
+        },
+    ]
+
+    version_file = {
+        'content': base64.b64encode(b'__version__ = "1.2.1.dev"\n'),
+    }
+
+    getiter = {
+        commits_url: commits,
+        comments_url: comments,
+    }
+
+    getitem = {
+        commit_url_template.format(sha=sha_1): commit_add,
+        commit_url_template.format(sha=sha_2): commit_modify,
+        commit_url_template.format(sha=sha_3): commit_delete,
+        version_url: version_file,
+    }
+    post = {
+        comments_url: {
+            'html_url': comment_html_url,
+        },
+        statuses_url: {},
+    }
+    patch = {
+        existing_added_deleted_comment_url: {
+            'html_url': comment_html_url2,
+        },
+        existing_comment_url: {
+            'html_url': comment_html_url,
+        },
+    }
+
+    event = _event(event_data)
+
+    gh = FakeGH(getiter=getiter, getitem=getitem, post=post, patch=patch)
+
+    await router.dispatch(event, gh)
+
+    getitem_urls = gh.getitem_urls
+    getiter_urls = gh.getiter_urls
+    post_urls = gh.post_urls
+    post_data = gh.post_data
+    patch_urls = gh.patch_urls
+    patch_data = gh.patch_data
+
+    assert getiter_urls == list(getiter)
+    assert getitem_urls == list(getitem)
+    assert post_urls == [statuses_url]
+    assert patch_urls == list(patch)
+    assert len(post_data) == 1
+    assert len(patch_data) == 2
+    # Comments data
+    assert patch_data[0].keys() == {"body"}
+    comment = patch_data[0]["body"]
+    assert ":white_check_mark:" not in comment
+    assert ":x:" not in comment
+    assert "\U0001f7e0" in comment
+    assert "error" not in comment
+    assert "add new files" in comment
+    assert "delete files" in comment
+    assert "https://github.com/sympy/sympy-bot" in comment
+    assert sha_1 in comment
+    assert sha_2 not in comment
+    assert sha_3 in comment
+    assert "`file1`" in comment
+    assert "<!-- BEGIN RELEASE NOTES -->" not in comment
+    assert "<!-- END RELEASE NOTES -->" not in comment
+
+@parametrize('action', ['opened', 'reopened', 'synchronize', 'edited'])
+async def test_added_deleted_remove_existing_comment(action):
+    # Based on test_status_good_existing_comment
+    event_data = {
+        'pull_request': {
+            'number': 1,
+            'state': 'open',
+            'merged': False,
+            'comments_url': comments_url,
+            'commits_url': commits_url,
+            'head': {
+                'user': {
+                    'login': 'asmeurer',
+                    },
+            },
+            'base': {
+                'repo': {
+                    'contents_url': contents_url,
+                    'html_url': html_url,
+                },
+                'ref': 'master',
+            },
+            'body': valid_PR_description,
+            'statuses_url': statuses_url,
+        },
+        'action': action,
+    }
+
+    commits = [
+        {
+            'author': {
+                'login': 'asmeurer',
+            },
+            'commit': {
+                'message': "Modifies file1"
+            },
+            'sha': sha,
+            'url': commit_url,
+        },
+    ]
+
+    commit = {
+        'sha': sha,
+        'files': [
+            {
+                'filename': 'file1',
+                'status': 'modified',
+            },
+        ]
+    }
+
+    comments = [
+        {
+            'user': {
+                'login': 'sympy-bot',
+            },
+            'url': existing_comment_url,
+            'body': comment_body,
+        },
+        {
+            'user': {
+                'login': 'sympy-bot',
+            },
+            'url': existing_added_deleted_comment_url,
+            'body': added_deleted_comment_body,
+        },
+        {
+            'user': {
+                'login': 'asmeurer',
+            },
+            'body': "comment",
+        },
+        {
+            'user': {
+                'login': 'certik',
+            },
+            'body': "comment",
+        },
+    ]
+
+    version_file = {
+        'content': base64.b64encode(b'__version__ = "1.2.1.dev"\n'),
+    }
+
+    getiter = {
+        commits_url: commits,
+        comments_url: comments,
+    }
+
+    getitem = {
+        commit_url: commit,
+        version_url: version_file,
+    }
+    post = {
+        comments_url: {
+            'html_url': comment_html_url,
+        },
+        statuses_url: {},
+    }
+    patch = {
+        existing_comment_url: {
+            'html_url': comment_html_url,
+        },
+    }
+    delete = {
+        existing_added_deleted_comment_url: {
+            'html_url': comment_html_url2,
+        },
+    }
+
+    event = _event(event_data)
+
+    gh = FakeGH(getiter=getiter, getitem=getitem, post=post, patch=patch, delete=delete)
+
+    await router.dispatch(event, gh)
+
+    getitem_urls = gh.getitem_urls
+    getiter_urls = gh.getiter_urls
+    post_urls = gh.post_urls
+    post_data = gh.post_data
+    patch_urls = gh.patch_urls
+    patch_data = gh.patch_data
+    delete_urls = gh.delete_urls
+
+    assert getiter_urls == list(getiter)
+    assert getitem_urls == list(getitem)
+    assert post_urls == [statuses_url]
+    assert patch_urls == list(patch)
+    assert delete_urls == list(delete)
+    assert len(post_data) == 1
+    assert len(patch_data) == 1
+    # Comments data
+    assert patch_data[0].keys() == {"body"}
+    comment = patch_data[0]["body"]
+    assert "release notes" in comment
+    assert "\U0001f7e0" not in comment
+    assert "add new files" not in comment
+    assert "delete files" not in comment
+    assert sha not in comment
+    assert "`file1`" not in comment

--- a/sympy_bot/tests/test_webapp.py
+++ b/sympy_bot/tests/test_webapp.py
@@ -121,6 +121,7 @@ release_notes_file = 'Release-Notes-for-1.2.1.md'
 comments_url = 'https://api.github.com/repos/sympy/sympy/pulls/1/comments'
 commits_url = 'https://api.github.com/repos/sympy/sympy/pulls/1/commits'
 contents_url = 'https://api.github.com/repos/sympy/sympy/contents/{+path}'
+sha = 'a109f824f4cb2b1dd97cf832f329d59da00d609a'
 version_url_template = 'https://api.github.com/repos/sympy/sympy/contents/sympy/release.py?ref={ref}'
 version_url = version_url_template.format(ref='master')
 html_url = "https://github.com/sympy/sympy"
@@ -234,7 +235,7 @@ async def test_status_good_new_comment(action):
             'commit': {
                 'message': "A good commit",
             },
-            'sha': 'a109f824f4cb2b1dd97cf832f329d59da00d609a',
+            'sha': sha,
         },
         {
             'author': {
@@ -243,7 +244,7 @@ async def test_status_good_new_comment(action):
             'commit': {
                 'message': "A good commit",
             },
-            'sha': 'a109f824f4cb2b1dd97cf832f329d59da00d609a',
+            'sha': sha,
         },
         # Test commits without a login
         {
@@ -251,7 +252,7 @@ async def test_status_good_new_comment(action):
             'commit': {
                 'message': "A good commit",
             },
-            'sha': 'a109f824f4cb2b1dd97cf832f329d59da00d609a',
+            'sha': sha,
         },
     ]
 
@@ -363,7 +364,7 @@ async def test_status_good_existing_comment(action):
             'commit': {
                 'message': "A good commit",
             },
-            'sha': 'a109f824f4cb2b1dd97cf832f329d59da00d609a',
+            'sha': sha,
         },
         {
             'author': {
@@ -372,7 +373,7 @@ async def test_status_good_existing_comment(action):
             'commit': {
                 'message': "A good commit",
             },
-            'sha': 'a109f824f4cb2b1dd97cf832f329d59da00d609a',
+            'sha': sha,
         },
         # Test commits without a login
         {
@@ -380,7 +381,7 @@ async def test_status_good_existing_comment(action):
             'commit': {
                 'message': "A good commit",
             },
-            'sha': 'a109f824f4cb2b1dd97cf832f329d59da00d609a',
+            'sha': sha,
         },
     ]
 
@@ -510,7 +511,7 @@ async def test_closed_with_merging(mocker, action):
             'commit': {
                 'message': "A good commit",
             },
-            'sha': 'a109f824f4cb2b1dd97cf832f329d59da00d609a',
+            'sha': sha,
         },
         {
             'author': {
@@ -519,7 +520,7 @@ async def test_closed_with_merging(mocker, action):
             'commit': {
                 'message': "A good commit",
             },
-            'sha': 'a109f824f4cb2b1dd97cf832f329d59da00d609a',
+            'sha': sha,
         },
         # Test commits without a login
         {
@@ -527,7 +528,7 @@ async def test_closed_with_merging(mocker, action):
             'commit': {
                 'message': "A good commit",
             },
-            'sha': 'a109f824f4cb2b1dd97cf832f329d59da00d609a',
+            'sha': sha,
         },
     ]
 
@@ -672,7 +673,7 @@ async def test_closed_with_merging_no_entry(mocker, action):
             'commit': {
                 'message': "A good commit",
             },
-            'sha': 'a109f824f4cb2b1dd97cf832f329d59da00d609a',
+            'sha': sha,
         },
         {
             'author': {
@@ -681,7 +682,7 @@ async def test_closed_with_merging_no_entry(mocker, action):
             'commit': {
                 'message': "A good commit",
             },
-            'sha': 'a109f824f4cb2b1dd97cf832f329d59da00d609a',
+            'sha': sha,
         },
         # Test commits without a login
         {
@@ -689,7 +690,7 @@ async def test_closed_with_merging_no_entry(mocker, action):
             'commit': {
                 'message': "A good commit",
             },
-            'sha': 'a109f824f4cb2b1dd97cf832f329d59da00d609a',
+            'sha': sha,
         },
     ]
 
@@ -825,7 +826,7 @@ async def test_closed_with_merging_update_wiki_error(mocker, action, exception):
             'commit': {
                 'message': "A good commit",
             },
-            'sha': 'a109f824f4cb2b1dd97cf832f329d59da00d609a',
+            'sha': sha,
         },
         {
             'author': {
@@ -834,7 +835,7 @@ async def test_closed_with_merging_update_wiki_error(mocker, action, exception):
             'commit': {
                 'message': "A good commit",
             },
-            'sha': 'a109f824f4cb2b1dd97cf832f329d59da00d609a',
+            'sha': sha,
         },
         # Test commits without a login
         {
@@ -842,7 +843,7 @@ async def test_closed_with_merging_update_wiki_error(mocker, action, exception):
             'commit': {
                 'message': "A good commit",
             },
-            'sha': 'a109f824f4cb2b1dd97cf832f329d59da00d609a',
+            'sha': sha,
         },
     ]
 
@@ -1005,7 +1006,7 @@ async def test_closed_with_merging_bad_status_error(mocker, action):
             'commit': {
                 'message': "A good commit",
             },
-            'sha': 'a109f824f4cb2b1dd97cf832f329d59da00d609a',
+            'sha': sha,
         },
         {
             'author': {
@@ -1014,7 +1015,7 @@ async def test_closed_with_merging_bad_status_error(mocker, action):
             'commit': {
                 'message': "A good commit",
             },
-            'sha': 'a109f824f4cb2b1dd97cf832f329d59da00d609a',
+            'sha': sha,
         },
         # Test commits without a login
         {
@@ -1022,7 +1023,7 @@ async def test_closed_with_merging_bad_status_error(mocker, action):
             'commit': {
                 'message': "A good commit",
             },
-            'sha': 'a109f824f4cb2b1dd97cf832f329d59da00d609a',
+            'sha': sha,
         },
     ]
 
@@ -1159,7 +1160,7 @@ async def test_status_bad_new_comment(action):
             'commit': {
                 'message': "A good commit",
             },
-            'sha': 'a109f824f4cb2b1dd97cf832f329d59da00d609a',
+            'sha': sha,
         },
         {
             'author': {
@@ -1168,7 +1169,7 @@ async def test_status_bad_new_comment(action):
             'commit': {
                 'message': "A good commit",
             },
-            'sha': 'a109f824f4cb2b1dd97cf832f329d59da00d609a',
+            'sha': sha,
         },
         # Test commits without a login
         {
@@ -1176,7 +1177,7 @@ async def test_status_bad_new_comment(action):
             'commit': {
                 'message': "A good commit",
             },
-            'sha': 'a109f824f4cb2b1dd97cf832f329d59da00d609a',
+            'sha': sha,
         },
     ]
 
@@ -1284,7 +1285,7 @@ async def test_status_bad_existing_comment(action):
             'commit': {
                 'message': "A good commit",
             },
-            'sha': 'a109f824f4cb2b1dd97cf832f329d59da00d609a',
+            'sha': sha,
         },
         {
             'author': {
@@ -1293,7 +1294,7 @@ async def test_status_bad_existing_comment(action):
             'commit': {
                 'message': "A good commit",
             },
-            'sha': 'a109f824f4cb2b1dd97cf832f329d59da00d609a',
+            'sha': sha,
         },
         # Test commits without a login
         {
@@ -1301,7 +1302,7 @@ async def test_status_bad_existing_comment(action):
             'commit': {
                 'message': "A good commit",
             },
-            'sha': 'a109f824f4cb2b1dd97cf832f329d59da00d609a',
+            'sha': sha,
         },
     ]
 
@@ -1418,7 +1419,7 @@ async def test_rate_limit_comment(action):
             'commit': {
                 'message': "A good commit",
             },
-            'sha': 'a109f824f4cb2b1dd97cf832f329d59da00d609a',
+            'sha': sha,
         },
         {
             'author': {
@@ -1427,7 +1428,7 @@ async def test_rate_limit_comment(action):
             'commit': {
                 'message': "A good commit",
             },
-            'sha': 'a109f824f4cb2b1dd97cf832f329d59da00d609a',
+            'sha': sha,
         },
         # Test commits without a login
         {
@@ -1435,7 +1436,7 @@ async def test_rate_limit_comment(action):
             'commit': {
                 'message': "A good commit",
             },
-            'sha': 'a109f824f4cb2b1dd97cf832f329d59da00d609a',
+            'sha': sha,
         },
     ]
 
@@ -1546,7 +1547,7 @@ async def test_header_in_message(action):
             'commit': {
                 'message': "A good commit",
             },
-            'sha': 'a109f824f4cb2b1dd97cf832f329d59da00d609a',
+            'sha': sha,
         },
         # Test commits without a login
         {
@@ -1554,7 +1555,7 @@ async def test_header_in_message(action):
             'commit': {
                 'message': "A good commit",
             },
-            'sha': 'a109f824f4cb2b1dd97cf832f329d59da00d609a',
+            'sha': sha,
         },
     ]
 
@@ -1661,7 +1662,7 @@ async def test_bad_version_file(action):
             'commit': {
                 'message': "A good commit",
             },
-            'sha': 'a109f824f4cb2b1dd97cf832f329d59da00d609a',
+            'sha': sha,
         },
         {
             'author': {
@@ -1670,7 +1671,7 @@ async def test_bad_version_file(action):
             'commit': {
                 'message': "A good commit",
             },
-            'sha': 'a109f824f4cb2b1dd97cf832f329d59da00d609a',
+            'sha': sha,
         },
         # Test commits without a login
         {
@@ -1678,7 +1679,7 @@ async def test_bad_version_file(action):
             'commit': {
                 'message': "A good commit",
             },
-            'sha': 'a109f824f4cb2b1dd97cf832f329d59da00d609a',
+            'sha': sha,
         },
     ]
 
@@ -1791,7 +1792,7 @@ async def test_no_user_logins_in_commits(action, include_extra):
             'commit': {
                 'message': "A good commit",
             },
-            'sha': 'a109f824f4cb2b1dd97cf832f329d59da00d609a',
+            'sha': sha,
         },
     ]
     if include_extra:
@@ -1803,7 +1804,7 @@ async def test_no_user_logins_in_commits(action, include_extra):
                 'commit': {
                     'message': "A good commit",
                 },
-                'sha': 'a109f824f4cb2b1dd97cf832f329d59da00d609a',
+                'sha': sha,
             },
         ]
 
@@ -1918,7 +1919,7 @@ async def test_status_good_new_comment_other_base(action):
             'commit': {
                 'message': "A good commit",
             },
-            'sha': 'a109f824f4cb2b1dd97cf832f329d59da00d609a',
+            'sha': sha,
         },
         {
             'author': {
@@ -1927,7 +1928,7 @@ async def test_status_good_new_comment_other_base(action):
             'commit': {
                 'message': "A good commit",
             },
-            'sha': 'a109f824f4cb2b1dd97cf832f329d59da00d609a',
+            'sha': sha,
         },
         # Test commits without a login
         {
@@ -1935,7 +1936,7 @@ async def test_status_good_new_comment_other_base(action):
             'commit': {
                 'message': "A good commit",
             },
-            'sha': 'a109f824f4cb2b1dd97cf832f329d59da00d609a',
+            'sha': sha,
         },
     ]
 

--- a/sympy_bot/webapp.py
+++ b/sympy_bot/webapp.py
@@ -86,7 +86,6 @@ async def pull_request_comment(event, gh):
         if BEGIN_RELEASE_NOTES in message or END_RELEASE_NOTES in message:
             header_in_message = commit['sha']
 
-        print('commit url', commit['url'])
         com = await gh.getitem(commit['url'])
         for file in com['files']:
             if file['status'] == 'added':

--- a/sympy_bot/webapp.py
+++ b/sympy_bot/webapp.py
@@ -201,18 +201,18 @@ Hi, I am the [SymPy bot](https://github.com/sympy/sympy-bot) ({BOT_VERSION}). I'
 The following commits add new files:
 """
         for sha, files in added.items():
-            added_deleted_message += f"{sha}:\n"
+            added_deleted_message += f"* {sha}:\n"
             for file in files:
-                added_deleted_message += f" - {file['filename']}\n"
+                added_deleted_message += f"  - `{file['filename']}`\n"
 
         if deleted:
             added_deleted_message += f"""
 The following commits delete files:
 """
         for sha, files in deleted.items():
-            added_deleted_message += f"{sha}:\n"
+            added_deleted_message += f"* {sha}:\n"
             for file in files:
-                added_deleted_message += f" - {file['filename']}\n"
+                added_deleted_message += f"  - `{file['filename']}`\n"
 
 
         if existing_comment_added_deleted:

--- a/sympy_bot/webapp.py
+++ b/sympy_bot/webapp.py
@@ -216,7 +216,7 @@ The following commits delete files:
 
 
         if existing_comment_added_deleted:
-            comment = await gh.patch(existing_comment_release_notes['url'], data={"body": added_deleted_message})
+            comment = await gh.patch(existing_comment_added_deleted['url'], data={"body": added_deleted_message})
         else:
             comment = await gh.post(comments_url, data={"body": added_deleted_message})
 

--- a/sympy_bot/webapp.py
+++ b/sympy_bot/webapp.py
@@ -92,6 +92,8 @@ async def pull_request_comment(event, gh):
                 added[com['sha']].append(file)
             elif file['status'] == 'deleted':
                 deleted[com['sha']].append(file)
+            else:
+                print(f"{file['filename']} was {file['status']}")
 
     if added:
         print("Files added:")

--- a/sympy_bot/webapp.py
+++ b/sympy_bot/webapp.py
@@ -191,8 +191,12 @@ Note: This comment will be updated with the latest check if you edit the pull re
 """
 
     if added or deleted:
+        # \U0001f7e0 is an orange circle. Don't include it here literally
+        # because it causes issues in some editors. We set it as a level 3
+        # header so it appears the same size as the GitHub :emojis:. It isn't
+        # available as a :emoji: unfortunately.
         added_deleted_message = f"""\
-### 🟠
+### \U0001f7e0
 
 Hi, I am the [SymPy bot](https://github.com/sympy/sympy-bot) ({BOT_VERSION}). I've noticed that some of your commits add or delete files. Since this is sometimes done unintentionally, I wanted to alert you about it.
 

--- a/sympy_bot/webapp.py
+++ b/sympy_bot/webapp.py
@@ -84,6 +84,7 @@ async def pull_request_comment(event, gh):
         message = commit['commit']['message']
         if BEGIN_RELEASE_NOTES in message or END_RELEASE_NOTES in message:
             header_in_message = commit['sha']
+        print(commit.keys())
         for file in commit['files']:
             if file['status'] == 'added':
                 added[commit['sha']] = file

--- a/sympy_bot/webapp.py
+++ b/sympy_bot/webapp.py
@@ -204,7 +204,7 @@ This is an experimental feature of SymPy Bot. If you have any feedback on it, pl
 """
         if added:
             added_deleted_message += f"""
-The following commits add new files:
+The following commits **add new files**:
 """
         for sha, files in added.items():
             added_deleted_message += f"* {sha}:\n"
@@ -213,7 +213,7 @@ The following commits add new files:
 
         if deleted:
             added_deleted_message += f"""
-The following commits delete files:
+The following commits **delete files**:
 """
         for sha, files in deleted.items():
             added_deleted_message += f"* {sha}:\n"

--- a/sympy_bot/webapp.py
+++ b/sympy_bot/webapp.py
@@ -93,7 +93,7 @@ async def pull_request_comment(event, gh):
             elif file['status'] == 'deleted':
                 deleted[com['sha']].append(file)
             else:
-                print(f"{file['filename']} was {file['status']}")
+                print(f"{file['filename']} was {file['status']} in {com['sha']}")
 
     if added:
         print("Files added:")

--- a/sympy_bot/webapp.py
+++ b/sympy_bot/webapp.py
@@ -195,6 +195,8 @@ Note: This comment will be updated with the latest check if you edit the pull re
 ### 🟠
 
 Hi, I am the [SymPy bot](https://github.com/sympy/sympy-bot) ({BOT_VERSION}). I've noticed that some of your commits add or delete files. Since this is sometimes done unintentionally, I wanted to alert you about it.
+
+This is an experimental feature of SymPy Bot. If you have any feedback on it, please comment at https://github.com/sympy/sympy-bot/issues/75.
 """
         if added:
             added_deleted_message += f"""

--- a/sympy_bot/webapp.py
+++ b/sympy_bot/webapp.py
@@ -86,6 +86,7 @@ async def pull_request_comment(event, gh):
         if BEGIN_RELEASE_NOTES in message or END_RELEASE_NOTES in message:
             header_in_message = commit['sha']
 
+        print('commit url', commit['url'])
         com = await gh.getitem(commit['url'])
         for file in com['files']:
             if file['status'] == 'added':

--- a/sympy_bot/webapp.py
+++ b/sympy_bot/webapp.py
@@ -84,7 +84,7 @@ async def pull_request_comment(event, gh):
         message = commit['commit']['message']
         if BEGIN_RELEASE_NOTES in message or END_RELEASE_NOTES in message:
             header_in_message = commit['sha']
-        print(commit.keys())
+        print(commit)
         for file in commit['files']:
             if file['status'] == 'added':
                 added[commit['sha']] = file

--- a/sympy_bot/webapp.py
+++ b/sympy_bot/webapp.py
@@ -144,7 +144,6 @@ There was an error getting the version from the `{RELEASE_FILE}` file. Please op
     emoji_status = {
         True: ':white_check_mark:',
         False: ':x:',
-        None: '
         }
 
     if status:

--- a/sympy_bot/webapp.py
+++ b/sympy_bot/webapp.py
@@ -105,15 +105,15 @@ async def pull_request_comment(event, gh):
     # Try to find an existing comment to update
     existing_comment_release_notes = None
     existing_comment_added_deleted = None
-    mentioned = []
+    # mentioned = []
     async for comment in comments:
         if comment['user']['login'] == USER:
             if "release notes entry" in comment['body']:
                 existing_comment_release_notes = comment
             elif "add or delete" in comment['body']:
                 existing_comment_added_deleted = comment
-        if f'@{USER}' in comment['body']:
-            mentioned.append(comment)
+        # if f'@{USER}' in comment['body']:
+        #     mentioned.append(comment)
 
     status, message, changelogs = get_changelog(event.data['pull_request']['body'])
 

--- a/sympy_bot/webapp.py
+++ b/sympy_bot/webapp.py
@@ -84,12 +84,14 @@ async def pull_request_comment(event, gh):
         message = commit['commit']['message']
         if BEGIN_RELEASE_NOTES in message or END_RELEASE_NOTES in message:
             header_in_message = commit['sha']
-        print(commit)
-        for file in commit['files']:
+
+        com = await gh.getitem(commit['url'])
+        print(com)
+        for file in com['files']:
             if file['status'] == 'added':
-                added[commit['sha']] = file
+                added[com['sha']] = file
             elif file['status'] == 'deleted':
-                deleted[commit['sha']] = file
+                deleted[com['sha']] = file
 
     if added:
         print("Files added:")

--- a/sympy_bot/webapp.py
+++ b/sympy_bot/webapp.py
@@ -233,7 +233,7 @@ If these files were added/deleted on purpose, you can ignore this message.
     elif existing_comment_added_deleted:
         # Files were added or deleted before but now they aren't, so delete
         # the comment
-        await gh.delete(existing_comment_added_deleted)
+        await gh.delete(existing_comment_added_deleted['url'])
 
     if existing_comment_release_notes:
         comment = await gh.patch(existing_comment_release_notes['url'], data={"body": release_notes_message})

--- a/sympy_bot/webapp.py
+++ b/sympy_bot/webapp.py
@@ -75,13 +75,38 @@ async def pull_request_comment(event, gh):
     commits = gh.getiter(commits_url)
     users = set()
     header_in_message = False
+    added = {}
+    deleted = {}
+
     async for commit in commits:
         if commit['author']:
             users.add(commit['author']['login'])
         message = commit['commit']['message']
         if BEGIN_RELEASE_NOTES in message or END_RELEASE_NOTES in message:
             header_in_message = commit['sha']
+        for file in commit['files']:
+            if file['status'] == 'added':
+                added[commit['sha']] = file
+            elif file['status'] == 'deleted':
+                deleted[commit['sha']] = file
 
+    if added:
+        print("Files added:")
+        for sha, files in added.values():
+            print(sha)
+            for file in files:
+                print(file['filename'])
+    else:
+        print("No files added")
+
+    if deleted:
+        print("Files deleted:")
+        for sha, files in deleted.values():
+            print(sha)
+            for file in files:
+                print(file['filename'])
+    else:
+        print("No files deleted")
 
     users.add(event.data['pull_request']['head']['user']['login'])
 

--- a/sympy_bot/webapp.py
+++ b/sympy_bot/webapp.py
@@ -3,6 +3,7 @@ import datetime
 import os
 import base64
 from subprocess import CalledProcessError
+from collections import defaultdict
 
 from aiohttp import web, ClientSession
 
@@ -75,8 +76,8 @@ async def pull_request_comment(event, gh):
     commits = gh.getiter(commits_url)
     users = set()
     header_in_message = False
-    added = {}
-    deleted = {}
+    added = defaultdict(list)
+    deleted = defaultdict(list)
 
     async for commit in commits:
         if commit['author']:
@@ -88,9 +89,9 @@ async def pull_request_comment(event, gh):
         com = await gh.getitem(commit['url'])
         for file in com['files']:
             if file['status'] == 'added':
-                added[com['sha']] = file
+                added[com['sha']].append(file)
             elif file['status'] == 'deleted':
-                deleted[com['sha']] = file
+                deleted[com['sha']].append(file)
 
     if added:
         print("Files added:")

--- a/sympy_bot/webapp.py
+++ b/sympy_bot/webapp.py
@@ -86,7 +86,6 @@ async def pull_request_comment(event, gh):
             header_in_message = commit['sha']
 
         com = await gh.getitem(commit['url'])
-        print(com)
         for file in com['files']:
             if file['status'] == 'added':
                 added[com['sha']] = file
@@ -95,7 +94,7 @@ async def pull_request_comment(event, gh):
 
     if added:
         print("Files added:")
-        for sha, files in added.values():
+        for sha, files in added.items():
             print(sha)
             for file in files:
                 print(file['filename'])
@@ -104,7 +103,7 @@ async def pull_request_comment(event, gh):
 
     if deleted:
         print("Files deleted:")
-        for sha, files in deleted.values():
+        for sha, files in deleted.items():
             print(sha)
             for file in files:
                 print(file['filename'])

--- a/sympy_bot/webapp.py
+++ b/sympy_bot/webapp.py
@@ -230,6 +230,10 @@ If these files were added/deleted on purpose, you can ignore this message.
             comment = await gh.patch(existing_comment_added_deleted['url'], data={"body": added_deleted_message})
         else:
             comment = await gh.post(comments_url, data={"body": added_deleted_message})
+    elif existing_comment_added_deleted:
+        # Files were added or deleted before but now they aren't, so delete
+        # the comment
+        await gh.delete(existing_comment_added_deleted)
 
     if existing_comment_release_notes:
         comment = await gh.patch(existing_comment_release_notes['url'], data={"body": release_notes_message})

--- a/sympy_bot/webapp.py
+++ b/sympy_bot/webapp.py
@@ -90,10 +90,10 @@ async def pull_request_comment(event, gh):
         for file in com['files']:
             if file['status'] == 'added':
                 added[com['sha']].append(file)
-            elif file['status'] == 'deleted':
+            elif file['status'] == 'removed':
                 deleted[com['sha']].append(file)
-            else:
-                print(f"{file['filename']} was {file['status']} in {com['sha']}")
+            # else:
+            #     print(f"{file['filename']} was {file['status']} in {com['sha']}")
 
     if added:
         print("Files added:")

--- a/sympy_bot/webapp.py
+++ b/sympy_bot/webapp.py
@@ -214,6 +214,11 @@ The following commits delete files:
             for file in files:
                 added_deleted_message += f"  - `{file['filename']}`\n"
 
+        added_deleted_message += f"""
+If these files were added/deleted on purpose, you can ignore this message.
+"""
+        # TODO: Allow users to whitelist files by @mentioning the bot. Then we
+        # could make this give a failing status.
 
         if existing_comment_added_deleted:
             comment = await gh.patch(existing_comment_added_deleted['url'], data={"body": added_deleted_message})


### PR DESCRIPTION
https://github.com/sympy/sympy-bot/issues/75

For now it just comments. But we could easily add functionality where someone with push access has to @mention the bot and whitelist files. 

This is what this looks like https://github.com/asmeurer/GitHub-Issues-Test/pull/44#issuecomment-586520029