### PR TITLE
Remove text about reloading the page

### DIFF
--- a/sympy_bot/submodules.txt
+++ b/sympy_bot/submodules.txt
@@ -28,8 +28,8 @@ logic
 matrices
 ntheory
 parsing
-# physics is disparate enough to list each submodule separately
 
+# physics is disparate enough to list each submodule separately
 physics.continuum_mechanics
 physics.gaussopt
 physics.hep

--- a/sympy_bot/tests/test_webapp.py
+++ b/sympy_bot/tests/test_webapp.py
@@ -181,7 +181,7 @@ Here is what the release notes will look like:
 
 This will be added to https://github.com/sympy/sympy/wiki/Release-Notes-for-1.2.1.
 
-Note: This comment will be updated with the latest check if you edit the pull request. You need to reload the page to see it. <details><summary>Click here to see the pull request description that was parsed.</summary>
+<details><summary>Click here to see the pull request description that was parsed.</summary>
 
 
     <!-- BEGIN RELEASE NOTES -->

--- a/sympy_bot/webapp.py
+++ b/sympy_bot/webapp.py
@@ -258,7 +258,7 @@ Hi, I am the [SymPy bot](https://github.com/sympy/sympy-bot) ({BOT_VERSION}). I'
 This is an experimental feature of SymPy Bot. If you have any feedback on it, please comment at https://github.com/sympy/sympy-bot/issues/75.
 """
         if added:
-            added_deleted_message += f"""
+            added_deleted_message += """
 The following commits **add new files**:
 """
         for sha, files in added.items():
@@ -267,7 +267,7 @@ The following commits **add new files**:
                 added_deleted_message += f"  - `{file['filename']}`\n"
 
         if deleted:
-            added_deleted_message += f"""
+            added_deleted_message += """
 The following commits **delete files**:
 """
         for sha, files in deleted.items():
@@ -275,7 +275,7 @@ The following commits **delete files**:
             for file in files:
                 added_deleted_message += f"  - `{file['filename']}`\n"
 
-        added_deleted_message += f"""
+        added_deleted_message += """
 If these files were added/deleted on purpose, you can ignore this message.
 """
         # TODO: Allow users to whitelist files by @mentioning the bot. Then we

--- a/sympy_bot/webapp.py
+++ b/sympy_bot/webapp.py
@@ -170,7 +170,7 @@ Hi, I am the [SymPy bot](https://github.com/sympy/sympy-bot) ({BOT_VERSION}). I'
 
 {message}
 
-Note: This comment will be updated with the latest check if you edit the pull request. You need to reload the page to see it. <details><summary>Click here to see the pull request description that was parsed.</summary>
+<details><summary>Click here to see the pull request description that was parsed.</summary>
 
 {textwrap.indent(event.data['pull_request']['body'], '    ')}
 


### PR DESCRIPTION
It is no longer necessary to reload the page. GitHub now updates the comment
automatically.